### PR TITLE
avoid empty tag on enter/tab

### DIFF
--- a/lib/ReactTags.js
+++ b/lib/ReactTags.js
@@ -120,6 +120,10 @@ class ReactTags extends React.Component {
       return
     }
 
+    if(tag.name === ''){
+      return
+    }
+
     this.props.handleAddition(tag)
 
     // reset the state


### PR DESCRIPTION
added condition to avoid empty tag upon enter/tab when minQueryLength=0 props to show suggestion by default focus